### PR TITLE
chore: add temp cp command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build:platform": "tsc",
     "build:content": "node ./lib/index.js",
-    "build": "yarn build:platform && yarn build:content",
+    "build": "yarn build:platform && yarn build:content && cp -R ./assets ./public/",
     "test": "yarn build && jest",
     "test:dev": "jest --watch"
   },


### PR DESCRIPTION
Add a temporary `cp` command to the build to copy static assets to the `public` directory
